### PR TITLE
Fixed broken requirements link on start page

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ title: Ruboto
         <div class="tab-pane active" id="qs-install">
           <p>Ruboto depends on <a href="http://jruby.org/" target="_blank">JRuby</a>,
           which is a Java implementation of the Ruby programming language.</a>
-          Installation is straight-forward and easy. Please read the <a href="#documentation">Requirements</a>.</p>
+          Installation is straight-forward and easy. Please read the <a href="/documentation.html#requirements">Requirements</a>.</p>
           <div style="position: absolute; bottom: 0; left: 40px">
             <img src="images/steps/install.png" alt="Installation" />
           </div>


### PR DESCRIPTION
Now it heads directly to the requirements section on the Documentation page.
