### PR TITLE
Colouredtabs

### DIFF
--- a/assets/themes/ruboto/css/style.css
+++ b/assets/themes/ruboto/css/style.css
@@ -12,7 +12,7 @@ body {
   font-weight: 100;
 }
 
-.nav.nav-bar {
+.nav.nav-tabs {
  background-color: gainsboro;
 }
 


### PR DESCRIPTION
Hi 

I really find the tabs difficult to identify and I'm sure others are also not understanding that their clickable.
Here is a fix to make them coloured (gainsboro); with the active tab being white.

Secondly, Uwe - I think we are on the latest version of Bootstrap which is 2.3.2. I can't see in the recent history if someone had just done this.

Dane
