### PR TITLE
fix: Remove disabled widgets from home page

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
-    {% endif %}  
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/ruboto{{ layout.theme.name }}{% endcapture %}
+    {% endif %}
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ title: Ruboto
   <div class="row">
     <div class="span5 offset1">
       <h1>Experience the fun of Ruby for Android</h1>
-      
-      <p><span>Ruboto</span> is a <span>framework and tool chain</span> to develop 
+
+      <p><span>Ruboto</span> is a <span>framework and tool chain</span> to develop
       <span>native Android</span> apps, using the <span>Ruby</span> language
         we all know and love.</p>
 
@@ -46,12 +46,10 @@ title: Ruboto
       <h2><a href="https://github.com/ruboto/ruboto-irb" target="_blank">Ruboto-IRB</a></h2>
 
       <div id="ruboto-irb">
-        <p class="tryme">Useful applications. <a href="#">Try now >>></a></p>
-        <script type='text/javascript' src='//www.appsurfer.com/surf.js.js'></script>
+        <p class="tryme">Useful applications.</p>
         <iframe src="http://ghbtns.com/github-btn.html?user=ruboto&repo=ruboto-irb&type=watch&count=true"
             allowtransparency="true" frameborder="0" scrolling="0" width="85" height="20"></iframe>
       </div>
-      <p id="surfit"><iframe src='//www.appsurfer.com/apps/19417-ruboto-irb-ruby-on-android/buttons/small_hz' scrolling='no' frameborder='0' style='height:35px; width:100px;border:none;' class='ASWButtonFrame' data-domain='http://www.appsurfer.com'></iframe></p>
 
     </div>
   </div>


### PR DESCRIPTION
- Removed empty "Try Now >>>" href.
- Removed disabled Surf it link.
- Fixed JB Setup asset path causing development assets 404 error.